### PR TITLE
Add custom tkltest-unit setup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,9 @@ RUN wget -qO /opt/tackle-test-generator-cli.zip $TESTGEN \
  && unzip /opt/tackle-test-generator-cli.zip -d /opt \
  && rm /opt/tackle-test-generator-cli.zip
 
+# Override setup.py with custom versions with limited dependencies (test unit-only)
+COPY hack/setup.py /opt/tackle-test-generator-cli/
+
 # Install tkltest-unit
 RUN cd /opt/tackle-test-generator-cli && pip3 install --editable .
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Docker Repository on Quay](https://quay.io/repository/konveyor/tackle2-addon-test-generator/status "Docker Repository on Quay")](https://quay.io/repository/konveyor/tackle2-addon-test-generator)
+
 # Development of Tackle2 addon with test generator
 
 The tool which should be implemented as an addon: https://github.com/konveyor/tackle-test-generator-cli

--- a/hack/addon.yaml
+++ b/hack/addon.yaml
@@ -6,4 +6,4 @@ apiVersion: tackle.konveyor.io/v1alpha1
 metadata:
   name: testgen
 spec:
-  image: quay.io/maufart/tackle2-addon-test-generator
+  image: quay.io/konveyor/tackle2-addon-test-generator

--- a/hack/setup.py
+++ b/hack/setup.py
@@ -1,0 +1,61 @@
+# originaly from https://github.com/konveyor/tackle-test-generator-cli/blob/main/setup.py
+
+import tkltest
+from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+
+class TkltestInstall(install):
+    """Install and download nltk data"""
+    def run(self):
+        install.run(self)
+#        import nltk
+#        nltk.download('stopwords')
+#        nltk.download('averaged_perceptron_tagger')
+#        nltk.download('wordnet')
+#        nltk.download('words')
+#        nltk.download('omw-1.4')
+
+
+setup(
+    name='tkltest',
+    version=tkltest.__version__,
+    description='Command-line interface for generating and executing test cases on'
+                'two application versions and performing differential testing',
+    packages=find_packages(),
+    install_requires=[
+        'coverage==5.5',
+        'nose==1.3.7',
+        'PyYAML>=5.4',
+        'tabulate==0.8.9',
+        'textile==4.0.1',
+        'toml==0.10.2',
+        'yattag==1.14.0',
+        'jinja2==3.0.2',
+        'bs4==0.0.1',
+        'kaitaistruct==0.9',
+        'psutil==5.9.0',
+        'tqdm==4.62.3',
+#        'nltk>=3.6.6',
+        'pyenchant==3.2.2',
+        'lxml==4.9.1',
+        'xmltodict==0.12.0',
+        'keybert==0.4.0',
+        'pandas==1.4.3'
+
+    ],
+ #   setup_requires=['nltk==3.6.6'],
+    cmdclass={'install': TkltestInstall},
+    entry_points={
+        "console_scripts": [
+            "tkltest-unit = tkltest.tkltest_unit:main",
+#            "tkltest-ui = tkltest.tkltest_ui:main"
+        ]
+    },
+    include_package_data=True,
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: APL-2.0',
+        'Operating System :: OS Independent'
+    ]
+)

--- a/hack/setup.py
+++ b/hack/setup.py
@@ -1,4 +1,8 @@
-# originaly from https://github.com/konveyor/tackle-test-generator-cli/blob/main/setup.py
+#
+# File originaly from https://github.com/konveyor/tackle-test-generator-cli/blob/main/setup.py
+#
+# TODO: Required dependencies list should be minimized more if possible (L30-48).
+#
 
 import tkltest
 from setuptools import setup, find_packages


### PR DESCRIPTION
Adding custom setup.py script from https://github.com/konveyor/tackle-test-generator-cli to focus on unit tests only.

The setup.py script is WIP, dependencies should be minimized more if possible.

Adding link to image builds from the quay.io.

Signed-off-by: Marek Aufart <maufart@redhat.com>